### PR TITLE
Fix pypa/gh-action-pypi-publish version tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,4 +43,4 @@ jobs:
         run: ls -l
 
       - name: publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.13
+        uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
Fix version tag: v1.13 → v1.13.0